### PR TITLE
Added lock to send_email

### DIFF
--- a/mmeds/config.py
+++ b/mmeds/config.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from random import choice
 from pandas import read_csv, Timestamp
+from multiprocessing import Lock
 import pymysql as pms
 import mmeds.secrets as sec
 import mmeds.html as html
@@ -16,6 +17,8 @@ import re
 ############################
 # CONFIGURE SERVER GLOBALS #
 ############################
+global EMAIL_LOCK
+EMAIL_LOCK = Lock()
 
 UPLOADED_FP = 'uploaded_file'
 ERROR_FP = 'error_log.tsv'

--- a/mmeds/util.py
+++ b/mmeds/util.py
@@ -15,7 +15,6 @@ from email import message_from_bytes
 from time import sleep
 from re import sub
 from ppretty import ppretty
-from multiprocessing import Lock
 
 import yaml
 import mmeds.config as fig

--- a/mmeds/util.py
+++ b/mmeds/util.py
@@ -15,6 +15,7 @@ from email import message_from_bytes
 from time import sleep
 from re import sub
 from ppretty import ppretty
+from multiprocessing import Lock
 
 import yaml
 import mmeds.config as fig
@@ -847,6 +848,7 @@ def send_email(toaddr, user, message='upload', testing=False, **kwargs):
         # Add in any necessary text fields
         msg.set_content(email_body)
 
+        fig.EMAIL_LOCK.acquire()
         # Connect to the server and send the mail
         # server = SMTP('smtp.gmail.com', 587)
         server = SMTP('smtp.office365.com', 587)
@@ -854,6 +856,7 @@ def send_email(toaddr, user, message='upload', testing=False, **kwargs):
         server.login(fig.MMEDS_EMAIL, sec.EMAIL_PASS)
         server.send_message(msg)
         server.quit()
+        fig.EMAIL_LOCK.release()
     else:
         script = 'echo "{body}" | mail -s "{subject}" "{toaddr}"'
         if 'summary' in kwargs.keys():


### PR DESCRIPTION
# Pull Request Template for MMEDS
Added a global lock to the send_email function since STMPlib can error if two processes try to send an email at the same time. I haven't encountered this issue on chimera with xmail, only in the testing setup. If it turns out to be an issue on chimera as well I'll move `aquire()` and `release()` so they cover both the testing and non-testing setups.

## What has changed
Include each file that was changed, how it was changed (in broad terms), and why it was changed.

## Checklist of pre-requisites
-   [x] Does the code run?  
-   [x] Does the code follow the repository style?  
-   [x] Is the code tested?  

## How to use the feature
Example: To do X run new function Y with parameters A, B, and C which gives result Z.

## How the design has changed
Example: Functions A, B, and C are now all methods of Class D.

## Additional notes
