### PR TITLE
Bug fix split study analysis access

### DIFF
--- a/mmeds/database.py
+++ b/mmeds/database.py
@@ -555,7 +555,7 @@ class Database:
     @classmethod
     def get_all_studies(cls):
         """ Return all studies currently stored in the database. """
-        return MMEDSDoc.objects()
+        return MMEDSDoc.objects(doc_type='study')
 
     @classmethod
     def get_all_analyses_from_study(cls, access_code):
@@ -822,7 +822,8 @@ class MetaDataUploader(Process):
         self.mdata = MMEDSDoc(created=datetime.utcnow(),
                               last_accessed=datetime.utcnow(),
                               testing=self.testing,
-                              doc_type='study-' + self.study_type,
+                              doc_type='study',
+                              tool_type=self.study_type,
                               reads_type=self.reads_type,
                               barcodes_type=self.barcodes_type,
                               study_name=self.study_name,

--- a/mmeds/documents.py
+++ b/mmeds/documents.py
@@ -29,7 +29,8 @@ class MMEDSDoc(men.Document):
     reads_type = men.StringField(max_length=45)     # single_end or paired_end
     barcodes_type = men.StringField(max_length=45)  # Single or Paired
     data_type = men.StringField(max_length=45)  #
-    doc_type = men.StringField(max_length=45)
+    tool_type = men.StringField(max_length=45)  # Type of tool
+    doc_type = men.StringField(max_length=45)  # Study or Analysis
     analysis_type = men.StringField(max_length=45)
 
     # Stages: created, started, <Name of last method>, finished, errored
@@ -120,7 +121,7 @@ class MMEDSDoc(men.Document):
                          access_code=str(access_code),
                          reads_type=self.reads_type,
                          data_type=self.data_type,
-                         doc_type=self.doc_type,
+                         doc_type='analysis',
                          analysis_status='Pending',
                          restart_stage='0',
                          files=child_files,
@@ -159,7 +160,8 @@ class MMEDSDoc(men.Document):
                          reads_type=self.reads_type,
                          barcodes_type=self.barcodes_type,
                          data_type=self.data_type,
-                         doc_type=self.doc_type,
+                         tool_type=self.tool_type,
+                         doc_type='analysis',
                          analysis_status='Pending',
                          restart_stage='0',
                          files=child_files,
@@ -222,7 +224,8 @@ class MMEDSDoc(men.Document):
                        access_code=str(access_code),
                        reads_type=self.reads_type,
                        barcodes_type=self.barcodes_type,
-                       doc_type=tool_type,
+                       doc_type='analysis',
+                       tool_type=tool_type,
                        data_type=self.data_type,
                        analysis_type=analysis_type,
                        analysis_status='created',

--- a/mmeds/spawn.py
+++ b/mmeds/spawn.py
@@ -89,9 +89,9 @@ class Watcher(Process):
                 rmtree(ad.path)
         # Create the appropriate tool
         try:
-            tool = TOOLS[ad.doc_type](self.q, ad.owner, analysis_code, ad.study_code, ad.doc_type, ad.analysis_type,
-                                      ad.config, testing, analysis=run_analysis, restart_stage=restart_stage,
-                                      kill_stage=kill_stage)
+            tool = TOOLS[ad.tool_type](self.q, ad.owner, analysis_code, ad.study_code, ad.tool_type, ad.analysis_type,
+                                       ad.config, testing, analysis=run_analysis, restart_stage=restart_stage,
+                                       kill_stage=kill_stage)
         except KeyError:
             raise AnalysisError('Tool type did not match any')
         return tool

--- a/mmeds/tests/unit/test_documents.py
+++ b/mmeds/tests/unit/test_documents.py
@@ -41,6 +41,6 @@ class DocumentsTests(TestCase):
 
     def create_from_analysis(self):
         ad = docs.MMEDSDoc.objects(access_code='test_documents').first()
-        ad2 = ad.generate_sub_analysis_doc('Nationality', 'American', 'child_code')
+        ad2 = ad.generate_sub_analysis_doc(('Subject', 'Nationality'), 'American', 'child_code')
         self.assertEqual(ad2.owner, ad.owner)
         self.assertEqual(Path(ad.path), Path(ad2.path).parent)


### PR DESCRIPTION
# Pull Request Template for MMEDS
Fixed document property. MMEDSDoc.doc_type is now either 'analysis' or 'study' and MMEDSDoc.tool_type refers to the tool_type. The download_select_study page now filters by doc_type so it only displays studies

## What has changed
Include each file that was changed, how it was changed (in broad terms), and why it was changed.

## Checklist of pre-requisites
-   [x] Does the code run?  
-   [x] Does the code follow the repository style?  
-   [x] Is the code tested?  

## How to use the feature
Example: To do X run new function Y with parameters A, B, and C which gives result Z.

## How the design has changed
Example: Functions A, B, and C are now all methods of Class D.

## Additional notes
