### PR TITLE
Enhancement run on node

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.com/clemente-lab/mmeds-meta.png?branch=master)](https://travis-cl.com/clemente-lab/mmeds-meta)
 [![codecov](https://codecov.io/gh/clemente-lab/mmeds-meta/branch/master/graph/badge.svg)](https://codecov.io/gh/clemente-lab/mmeds-meta)
-[![CodeFactor](https://codefactor.io/repository/github/clemente-lab/mmeds-meta/badge/master)](https://codefactor.io/repository/github/clemente-lab/mmeds-meta/overview/master)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/e4cc5a646a8c4d53b55d6511e995657d)](https://www.codacy.com/manual/DSWallach/mmeds-meta?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=clemente-lab/mmeds-meta&amp;utm_campaign=Badge_Grade)
 
 ## Instructions

--- a/mmeds/config.py
+++ b/mmeds/config.py
@@ -552,6 +552,7 @@ HTML_ARGS = {
     'warning': '',
     'success': '',
     'javascript': IMAGE_PATH + 'mmeds.js',
+    'privilege': 'display:none',
 
     # Settings for highlighting the section of the web site currently being accessed
     'upload_selected': '',

--- a/mmeds/database.py
+++ b/mmeds/database.py
@@ -21,9 +21,6 @@ from mmeds.util import (send_email, pyformat_translate, quote_sql, parse_ICD_cod
                         debug_log, log, create_local_copy, load_metadata, join_metadata, write_metadata)
 from mmeds.documents import MMEDSDoc
 
-import multiprocessing_logging as mpl
-mpl.install_mp_handler()
-
 DAYS = 13
 
 

--- a/mmeds/database.py
+++ b/mmeds/database.py
@@ -30,7 +30,7 @@ DAYS = 13
 # Used in test_cases
 def upload_metadata(args):
     (subject_metadata, subject_type, specimen_metadata, path, owner, study_name,
-     reads_type, barcodes_type, for_reads, rev_reads, barcodes, access_code) = args
+     reads_type, barcodes_type, for_reads, rev_reads, barcodes, access_code, testing) = args
     if for_reads is not None and 'zip' in for_reads:
         datafiles = {'data': for_reads,
                      'barcodes': barcodes}
@@ -39,10 +39,8 @@ def upload_metadata(args):
                      'rev_reads': rev_reads,
                      'barcodes': barcodes}
     p = MetaDataUploader(subject_metadata, subject_type, specimen_metadata, owner, 'qiime', reads_type,
-                         barcodes_type, study_name, False, datafiles,
-                         False, True, access_code)
-    p.run()
-    return 0
+                         barcodes_type, study_name, False, datafiles, False, testing, access_code)
+    return p.run()
 
 
 def upload_otu(args):
@@ -985,6 +983,7 @@ class MetaDataUploader(Process):
         # Update the doc to reflect the successful upload
         self.mdata.update(is_alive=False, exit_code=0)
         self.mdata.save()
+        return 0
 
     def import_metadata(self, **kwargs):
         """

--- a/mmeds/error.py
+++ b/mmeds/error.py
@@ -140,3 +140,11 @@ class FormatError(MmedsError):
     def __init__(self, missed):
         self.message = 'The following formating variables were not filled: {}'.format(missed)
         super().__init__()
+
+
+class PrivilegeError(MmedsError):
+    """ Exception for attempts to use privileged features by non-privileged users"""
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__()

--- a/mmeds/html/analysis_select_tool.html
+++ b/mmeds/html/analysis_select_tool.html
@@ -18,7 +18,7 @@
         </select>
         </p>
         <p style="{privilege}">
-        <input class="w3-check" type='checkbox' name='onNode' form='analysis_form'/>
+        <input class="w3-check" type='checkbox' name='runOnNode' form='analysis_form'/>
         <label> Run analysis on Node </label>
         </p>
         <p>

--- a/mmeds/html/analysis_select_tool.html
+++ b/mmeds/html/analysis_select_tool.html
@@ -17,9 +17,13 @@
             <option value="picrust1">PiCRUSt1</option>
         </select>
         </p>
+        <p style="{privilege}">
+        <input class="w3-check" type='checkbox' name='onNode' form='analysis_form'/>
+        <label> Run analysis on Node </label>
+        </p>
         <p>
         <label> If you do not upload a custom config the default will be used. </label>
-        <input class="upload-btn-wrapper w3-btn w3-border w3-input" type="file" name="config" required>
+        <input class="upload-btn-wrapper w3-btn w3-border w3-input" type="file" name="config">
         </p>
         <p> <button class="w3-btn w3-blue" type='submit' method='post'>Run</button> </p>
     </form>

--- a/mmeds/log.py
+++ b/mmeds/log.py
@@ -1,10 +1,8 @@
 import logging
 import mmeds.config as fig
-import multiprocessing_logging as mpl
 from multiprocessing import current_process
 
 loggers = {}
-mpl.install_mp_handler()
 
 
 class MMEDSLog():
@@ -12,18 +10,18 @@ class MMEDSLog():
     global loggers
 
     def __init__(self, name, testing=True):
+        # If the logger already exists grab it
         if loggers.get(name):
             self.logger = loggers.get(name)
         else:
+            self.logger = logging.getLogger(name)
             if 'error' in name.lower():
-                self.logger = logging.getLogger('Error')
                 self.logger.setLevel(logging.ERROR)
             elif 'info' in name.lower() or 'sql' in name.lower():
-                self.logger = logging.getLogger('Info')
                 self.logger.setLevel(logging.INFO)
             elif 'debug' in name.lower():
-                self.logger = logging.getLogger('Debug')
                 self.logger.setLevel(logging.DEBUG)
+
             if 'SQL' in name:
                 fh = logging.FileHandler(fig.SQL_LOG)
             else:
@@ -37,7 +35,12 @@ class MMEDSLog():
             self.logger.setLevel(logging.DEBUG)
             fh.setLevel(logging.DEBUG)
 
-            formatter = logging.Formatter('%(asctime)s -%(levelname)s - %(message)s')
+            #  logging.basicConfig(format='%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',
+            #                          datefmt='%Y-%m-%d:%H:%M:%S',
+            #                          level=logging.DEBUG)
+
+            fmt_str = 'h[%(asctime)s] p%(process)s {%(filename)s:%(lineno)d} %(levelname)s - %(message)s'
+            formatter = logging.Formatter(fmt_str, '%m-%d %H:%M:%S')
             fh.setFormatter(formatter)
 
             ch = logging.StreamHandler()

--- a/mmeds/server.py
+++ b/mmeds/server.py
@@ -130,9 +130,6 @@ class MMEDSbase:
 
             # If a user is logged in, load the side bar
             if header:
-                # Add unhide any privileged options
-                if check_privileges(self.get_user(), self.testing):
-                    args['privilege'] = ''
                 template = HTML_PAGES['logged_in_template'].read_text()
                 if args.get('user') is None:
                     args['user'] = self.get_user()
@@ -777,7 +774,11 @@ class MMEDSanalysis(MMEDSbase):
     @cp.expose
     def analysis_page(self):
         """ Page for running analysis of previous uploads. """
-        page = self.load_webpage('analysis_select_tool', title='Select Analysis')
+        # Add unhide any privileged options
+        if check_privileges(self.get_user(), self.testing):
+            page = self.load_webpage('analysis_select_tool', title='Select Analysis', privilege='')
+        else:
+            page = self.load_webpage('analysis_select_tool', title='Select Analysis')
         return page
 
 

--- a/mmeds/server.py
+++ b/mmeds/server.py
@@ -725,7 +725,7 @@ class MMEDSanalysis(MMEDSbase):
         return page
 
     @cp.expose
-    def run_analysis(self, access_code, analysis_method, config, onNode):
+    def run_analysis(self, access_code, analysis_method, config, runOnNode):
         """
         Run analysis on the specified study
         ----------------------------------------
@@ -742,7 +742,7 @@ class MMEDSanalysis(MMEDSbase):
             # The run on node option shouldn't appear for users without
             # elevated privileges but they could get around that by editting
             # the page html directly
-            if onNode and not check_privileges(self.get_user(), self.testing):
+            if runOnNode and not check_privileges(self.get_user(), self.testing):
                 raise err.PrivilegeError('Only users with elevated privileges may run analysis directly')
 
             # Check that the requested upload exists
@@ -757,7 +757,7 @@ class MMEDSanalysis(MMEDSbase):
 
             # -1 is the kill_stage (used when testing)
             self.q.put(('analysis', self.get_user(), access_code, tool_type,
-                        analysis_type, config_path, -1, onNode))
+                        analysis_type, config_path, -1, runOnNode))
             page = self.load_webpage('home', title='Welcome to MMEDS',
                                      success='Analysis started you will recieve an email shortly')
         except (err.InvalidConfigError, err.MissingUploadError,

--- a/mmeds/server.py
+++ b/mmeds/server.py
@@ -21,12 +21,9 @@ from mmeds.database import Database
 from mmeds.spawn import handle_modify_data
 from mmeds.log import MMEDSLog
 
-import multiprocessing_logging as mpl
-mpl.install_mp_handler()
-
 absDir = Path(os.getcwd())
 
-logger = MMEDSLog('debug').logger
+logger = MMEDSLog('server-debug').logger
 
 
 def kill_watcher(monitor):

--- a/mmeds/spawn.py
+++ b/mmeds/spawn.py
@@ -77,7 +77,7 @@ class Watcher(Process):
             raise AnalysisError('Tool type did not match any')
         return tool
 
-    def restart_analysis(self, user, analysis_code, restart_stage, testing, kill_stage=-1, run_analysis=True):
+    def restart_analysis(self, user, analysis_code, restart_stage, testing, on_node, kill_stage=-1, run_analysis=True):
         """ Restart the specified analysis. """
         with Database('.', owner=user, testing=testing) as db:
             ad = db.get_doc(analysis_code)
@@ -91,7 +91,7 @@ class Watcher(Process):
         # Create the appropriate tool
         try:
             tool = TOOLS[ad.tool_type](self.q, ad.owner, analysis_code, ad.study_code, ad.tool_type, ad.analysis_type,
-                                       ad.config, testing, analysis=run_analysis, restart_stage=restart_stage,
+                                       ad.config, testing, on_node, analysis=run_analysis, restart_stage=restart_stage,
                                        kill_stage=kill_stage)
         except KeyError:
             raise AnalysisError('Tool type did not match any')
@@ -256,9 +256,9 @@ class Watcher(Process):
         ====================================================================
         Handles creating new processes to restart previous analyses.
         """
-        ptype, user, analysis_code, restart_stage, kill_stage = process
+        ptype, user, analysis_code, on_node, restart_stage, kill_stage = process
         p = self.restart_analysis(user, analysis_code, restart_stage, self.testing,
-                                  kill_stage=kill_stage, run_analysis=True)
+                                  on_node, kill_stage=kill_stage, run_analysis=True)
         # Start the analysis running
         p.start()
         sleep(1)

--- a/mmeds/spawn.py
+++ b/mmeds/spawn.py
@@ -62,7 +62,7 @@ class Watcher(Process):
         self.started = []
         super().__init__()
 
-    def spawn_analysis(self, tool_type, analysis_type, user, parent_code, config_file, testing, kill_stage=-1):
+    def spawn_analysis(self, tool_type, analysis_type, user, parent_code, config_file, testing, on_node, kill_stage=-1):
         """ Start running the analysis in a new process """
         # Load the config for this analysis
         with Database('.', owner=user, testing=testing) as db:
@@ -70,7 +70,8 @@ class Watcher(Process):
             access_code = db.create_access_code()
         config = load_config(config_file, files['metadata'])
         try:
-            tool = TOOLS[tool_type](self.q, user, access_code, parent_code, tool_type, analysis_type, config, testing,
+            tool = TOOLS[tool_type](self.q, user, access_code, parent_code, tool_type,
+                                    analysis_type, config, testing, on_node,
                                     kill_stage=kill_stage)
         except KeyError:
             raise AnalysisError('Tool type did not match any')
@@ -204,8 +205,9 @@ class Watcher(Process):
         ====================================================================
         Handles the creation of analysis processes
         """
-        ptype, user, access_code, tool_type, analysis_type, config, kill_stage = process
-        p = self.spawn_analysis(tool_type, analysis_type, user, access_code, config, self.testing, kill_stage)
+        ptype, user, access_code, tool_type, analysis_type, config, kill_stage, on_node = process
+        p = self.spawn_analysis(tool_type, analysis_type, user, access_code,
+                                config, self.testing, kill_stage, on_node)
         # Start the analysis running
         p.start()
         sleep(1)

--- a/mmeds/spawn.py
+++ b/mmeds/spawn.py
@@ -18,9 +18,6 @@ from mmeds.tools.picrust1 import PiCRUSt1
 from mmeds.tools.tool import TestTool
 from mmeds.log import MMEDSLog
 
-import multiprocessing_logging as mpl
-mpl.install_mp_handler()
-
 TOOLS = {
     'qiime1': Qiime1,
     'qiime2': Qiime2,
@@ -66,7 +63,8 @@ class Watcher(Process):
         self.running_on_node = set()
         super().__init__()
 
-    def spawn_analysis(self, tool_type, analysis_type, user, parent_code, config_file, testing, run_on_node, kill_stage=-1):
+    def spawn_analysis(self, tool_type, analysis_type, user, parent_code,
+                       config_file, testing, run_on_node, kill_stage=-1):
         """ Start running the analysis in a new process """
         # Load the config for this analysis
         with Database('.', owner=user, testing=testing) as db:
@@ -81,7 +79,8 @@ class Watcher(Process):
             raise AnalysisError('Tool type did not match any')
         return tool
 
-    def restart_analysis(self, user, analysis_code, restart_stage, testing, run_on_node, kill_stage=-1, run_analysis=True):
+    def restart_analysis(self, user, analysis_code, restart_stage, testing,
+                         run_on_node, kill_stage=-1, run_analysis=True):
         """ Restart the specified analysis. """
         with Database('.', owner=user, testing=testing) as db:
             ad = db.get_doc(analysis_code)
@@ -94,9 +93,9 @@ class Watcher(Process):
                 rmtree(ad.path)
         # Create the appropriate tool
         try:
-            tool = TOOLS[ad.tool_type](self.q, ad.owner, analysis_code, ad.study_code, ad.tool_type, ad.analysis_type,
-                                       ad.config, testing, run_on_node, analysis=run_analysis, restart_stage=restart_stage,
-                                       kill_stage=kill_stage)
+            tool = TOOLS[ad.tool_type](self.q, ad.owner, analysis_code, ad.study_code, ad.tool_type,
+                                       ad.analysis_type, ad.config, testing, run_on_node,
+                                       analysis=run_analysis, restart_stage=restart_stage, kill_stage=kill_stage)
         except KeyError:
             raise AnalysisError('Tool type did not match any')
         return tool
@@ -296,9 +295,6 @@ class Watcher(Process):
             self.check_processes()
             self.write_running_processes()
             self.log_processes()
-            self.logger.error('I am process {} named {}'.format(current_process(), self.name))
-            self.logger.error('In Watcher, current processes on node')
-            self.logger.error(self.running_on_node)
 
             # If there is nothing in the process queue, sleep
             if self.q.empty():
@@ -306,11 +302,21 @@ class Watcher(Process):
             else:
                 # Otherwise get the queued item
                 process = self.q.get()
-                # Retrieve the info
-                self.logger.debug(process)
-
+                self.logger.error('Got process requirements')
+                self.logger.error(process)
+                # If the watcher needs to shut down
+                if process == 'terminate':
+                    self.logger.error('Terminating')
+                    # Kill all the processes currently running
+                    for process in self.processes:
+                        self.logger.error('Killing process {}'.format(process))
+                        while process.is_alive():
+                            process.kill()
+                    # Notify other processes the watcher is exiting
+                    self.pipe.send('Watcher exiting')
+                    exit()
                 # If it's an analysis
-                if process[0] == 'analysis':
+                elif process[0] == 'analysis':
                     self.handle_analysis(process)
                 # If it's a restart of an analysis
                 elif process[0] == 'restart':
@@ -319,21 +325,10 @@ class Watcher(Process):
                 elif process[0] == 'upload':
                     current_upload = self.handle_upload(process, current_upload)
                 elif process[0] == 'email':
+                    self.logger.error('Sending email')
                     ptype, toaddr, user, message, kwargs = process
                     # If the analysis that finished was running directly on the node remove it from the set
                     if kwargs.get('access_code') in self.running_on_node:
                         self.running_on_node.remove(kwargs.get('access_code'))
 
                     send_email(toaddr, user, message, self.testing, **kwargs)
-                # If the watcher needs to shut down
-                elif process[0] == 'terminate':
-                    # Kill all the processes currently running
-                    for process in self.processes:
-                        while process.is_alive():
-                            process.kill()
-                    # Clear the pipe
-                    while not self.pipe.empty():
-                        self.pipe.recv()
-                    # Notify other processes the watcher is exiting
-                    self.pipe.send('Watcher exiting')
-                    exit()

--- a/mmeds/spawn.py
+++ b/mmeds/spawn.py
@@ -60,6 +60,7 @@ class Watcher(Process):
         self.pipe = pipe
         self.parent_pid = parent_pid
         self.started = []
+        self.running_on_node = 0
         super().__init__()
 
     def spawn_analysis(self, tool_type, analysis_type, user, parent_code, config_file, testing, on_node, kill_stage=-1):

--- a/mmeds/spawn.py
+++ b/mmeds/spawn.py
@@ -212,9 +212,10 @@ class Watcher(Process):
         if on_node:
             # Inform the user if there are too many processes already running
             if len(self.running_on_node) > 3:
-                with Database(testing=self.testing, owner=user) as db:
-                    toaddr = db.get_email()
+                with Database(testing=self.testing) as db:
+                    toaddr = db.get_email(user)
                 send_email(toaddr, user, 'too_many_on_node', self.testing, analysis=tool_type)
+                self.pipe.send('Analysis Not Started')
                 return
 
         # Otherwise continue

--- a/mmeds/tests/integration/test_analysis.py
+++ b/mmeds/tests/integration/test_analysis.py
@@ -36,6 +36,7 @@ class AnalysisTests(TestCase):
         self.watcher = spawn.Watcher(self.q, pipe_ends[1], mp.current_process(), self.testing)
         self.watcher.start()
         self.code = fig.TEST_CODE_SHORT
+        self.long_code = fig.TEST_CODE
 
     @classmethod
     def tearDownClass(self):
@@ -59,7 +60,7 @@ class AnalysisTests(TestCase):
             files, path = db.get_mongo_files(self.code)
         config = load_config(Path(fig.TEST_CONFIG_SUB), files['metadata'])
 
-        p = Qiime1(fig.TEST_USER, self.code, 'qiime1', 'closed', config, self.testing, True)
+        p = Qiime1(fig.TEST_USER, self.long_code, 'qiime1', 'closed', config, self.testing, True)
         p.start()
 
         while p.is_alive():

--- a/mmeds/tests/integration/test_analysis.py
+++ b/mmeds/tests/integration/test_analysis.py
@@ -20,7 +20,7 @@ are relevant to the current code section being modified.
 
 
 class AnalysisTests(TestCase):
-    testing = True
+    testing = False
     count = 0
 
     @classmethod
@@ -46,7 +46,6 @@ class AnalysisTests(TestCase):
         self.assertTrue((tool.path / 'summary').is_dir())
 
     def test_qiime1(self):
-        return
         self.q.put(('analysis', fig.TEST_USER, self.code, 'qiime1', 'closed', Path(fig.TEST_CONFIG), True, -1))
         got = self.pipe.recv()
         print(got)
@@ -55,13 +54,12 @@ class AnalysisTests(TestCase):
         self.assertEqual(self.pipe.recv(), 0)
 
     def test_qiime1_with_children(self):
-        return
         log('after data modification')
         with Database('.', owner=fig.TEST_USER, testing=self.testing) as db:
             files, path = db.get_mongo_files(self.code)
         config = load_config(Path(fig.TEST_CONFIG_SUB), files['metadata'])
 
-        p = Qiime1(fig.TEST_USER, self.code, 'qiime1', 'closed', config, self.testing)
+        p = Qiime1(fig.TEST_USER, self.code, 'qiime1', 'closed', config, self.testing, True)
         p.start()
 
         while p.is_alive():

--- a/mmeds/tests/integration/test_analysis.py
+++ b/mmeds/tests/integration/test_analysis.py
@@ -20,7 +20,7 @@ are relevant to the current code section being modified.
 
 
 class AnalysisTests(TestCase):
-    testing = False
+    testing = True
     count = 0
 
     @classmethod
@@ -35,18 +35,7 @@ class AnalysisTests(TestCase):
         self.pipe = pipe_ends[0]
         self.watcher = spawn.Watcher(self.q, pipe_ends[1], mp.current_process(), self.testing)
         self.watcher.start()
-        test_files = {'for_reads': fig.TEST_READS, 'barcodes': fig.TEST_BARCODES}
-        self.q.put(('upload', 'test_spawn', fig.TEST_SUBJECT, 'human', fig.TEST_SPECIMEN,
-                    fig.TEST_USER, 'single_end', 'single_barcodes', test_files, False, False))
-
-        # Assert upload has started
-        upload = self.pipe.recv()
-        self.code = upload['access_code']
-        sleep(120)
-
-        # Wait for upload to complete succesfully
-        self.pipe.recv()
-        print('data uploaded')
+        self.code = fig.TEST_CODE
 
     @classmethod
     def tearDownClass(self):
@@ -59,7 +48,7 @@ class AnalysisTests(TestCase):
 
     def test_qiime1(self):
         return
-        self.q.put(('analysis', fig.TEST_USER, self.code, 'qiime1', 'closed', Path(fig.TEST_CONFIG), -1))
+        self.q.put(('analysis', fig.TEST_USER, self.code, 'qiime1', 'closed', Path(fig.TEST_CONFIG), True, -1))
         got = self.pipe.recv()
         print(got)
 
@@ -93,7 +82,7 @@ class AnalysisTests(TestCase):
         self.summarize(0, p)
 
     def test_qiime2(self):
-        self.q.put(('analysis', fig.TEST_USER, self.code, 'qiime2', 'dada2', Path(fig.TEST_CONFIG), -1))
+        self.q.put(('analysis', fig.TEST_USER, self.code, 'qiime2', 'dada2', Path(fig.TEST_CONFIG), True, -1))
         # Get the info on the analysis
         self.pipe.recv()
 
@@ -103,7 +92,7 @@ class AnalysisTests(TestCase):
     def test_qiime2_with_restarts(self):
         return
         print('start initial analysis')
-        self.q.put(('analysis', fig.TEST_USER, self.code, 'qiime2', 'dada2', Path(fig.TEST_CONFIG), 1))
+        self.q.put(('analysis', fig.TEST_USER, self.code, 'qiime2', 'dada2', Path(fig.TEST_CONFIG), True, 1))
 
         # Get the info on the analysis
         analysis = self.pipe.recv()

--- a/mmeds/tests/integration/test_analysis.py
+++ b/mmeds/tests/integration/test_analysis.py
@@ -35,11 +35,10 @@ class AnalysisTests(TestCase):
         self.pipe = pipe_ends[0]
         self.watcher = spawn.Watcher(self.q, pipe_ends[1], mp.current_process(), self.testing)
         self.watcher.start()
-        self.code = fig.TEST_CODE
+        self.code = fig.TEST_CODE_SHORT
 
     @classmethod
     def tearDownClass(self):
-        remove_user(fig.TEST_USER, testing=self.testing)
         self.watcher.terminate()
 
     def summarize(self, count, tool):
@@ -90,8 +89,6 @@ class AnalysisTests(TestCase):
         self.assertEqual(self.pipe.recv(), 0)
 
     def test_qiime2_with_restarts(self):
-        return
-        print('start initial analysis')
         self.q.put(('analysis', fig.TEST_USER, self.code, 'qiime2', 'dada2', Path(fig.TEST_CONFIG), True, 1))
 
         # Get the info on the analysis
@@ -104,7 +101,7 @@ class AnalysisTests(TestCase):
         print('Initial analysis finished')
         # Test restarting from each checkpoint
         for i in range(1, 5):
-            self.q.put(('restart', fig.TEST_USER, code, i, i + 1))
+            self.q.put(('restart', fig.TEST_USER, code, True, i, i + 1))
             print('restart {} queued'.format(i))
             analysis = self.pipe.recv()
             exitcode = self.pipe.recv()

--- a/mmeds/tests/unit/test.py
+++ b/mmeds/tests/unit/test.py
@@ -16,7 +16,7 @@ import mmeds.secrets as sec
   - gives output as wanted for Travis CI
 """
 
-testing = True
+testing = False
 
 
 def add_users(tests):
@@ -49,7 +49,8 @@ def setup_tests(tests):
                            fig.TEST_READS,
                            None,
                            fig.TEST_BARCODES,
-                           fig.TEST_CODE_SHORT))
+                           fig.TEST_CODE_SHORT,
+                           testing))
         if 'tools' in tests:
             test_setup.append((fig.TEST_SUBJECT_SHORT,
                                'human',
@@ -62,7 +63,8 @@ def setup_tests(tests):
                                fig.TEST_READS,
                                fig.TEST_REV_READS,
                                fig.TEST_BARCODES,
-                               fig.TEST_CODE_PAIRED))
+                               fig.TEST_CODE_PAIRED,
+                               testing))
             test_setup.append((fig.TEST_SUBJECT_SHORT,
                                'human',
                                fig.TEST_SPECIMEN_SHORT,
@@ -74,7 +76,8 @@ def setup_tests(tests):
                                fig.TEST_DEMUXED,
                                None,
                                fig.TEST_BARCODES,
-                               fig.TEST_CODE_DEMUX))
+                               fig.TEST_CODE_DEMUX,
+                               testing))
             # Upload OTU if running test_tools.py
             test_otu = (fig.TEST_SUBJECT_SHORT,
                         'human',
@@ -83,7 +86,8 @@ def setup_tests(tests):
                         fig.TEST_USER,
                         'Test_SparCC',
                         fig.TEST_OTU,
-                        fig.TEST_CODE_OTU)
+                        fig.TEST_CODE_OTU,
+                        testing)
             assert 0 == upload_otu(test_otu)
             # Upload Lefse data if running test_tools.py
             test_lefse = (fig.TEST_SUBJECT_SHORT,
@@ -93,7 +97,8 @@ def setup_tests(tests):
                           fig.TEST_USER,
                           'Test_Lefse',
                           fig.TEST_LEFSE,
-                          fig.TEST_CODE_LEFSE)
+                          fig.TEST_CODE_LEFSE,
+                          testing)
             assert 0 == upload_lefse(test_lefse)
     if 'database' in tests:
         test_setup.append((fig.TEST_SUBJECT,
@@ -107,7 +112,8 @@ def setup_tests(tests):
                            fig.TEST_READS,
                            None,
                            fig.TEST_BARCODES,
-                           fig.TEST_CODE))
+                           fig.TEST_CODE,
+                           testing))
         test_setup.append((fig.TEST_ANIMAL_SUBJECT,
                            'animal',
                            fig.TEST_SPECIMEN,
@@ -119,7 +125,8 @@ def setup_tests(tests):
                            fig.TEST_READS,
                            None,
                            fig.TEST_BARCODES,
-                           fig.TEST_CODE))
+                           fig.TEST_CODE,
+                           testing))
         test_setup.append((fig.TEST_SUBJECT_ALT,
                            'human',
                            fig.TEST_SPECIMEN_ALT,
@@ -131,7 +138,8 @@ def setup_tests(tests):
                            fig.TEST_READS,
                            None,
                            fig.TEST_BARCODES,
-                           fig.TEST_CODE + '0'))
+                           fig.TEST_CODE + '0',
+                           testing))
     for setup in test_setup:
         assert 0 == upload_metadata(setup)
 

--- a/mmeds/tests/unit/test.py
+++ b/mmeds/tests/unit/test.py
@@ -12,8 +12,7 @@ import mmeds.secrets as sec
 - To run all the tests: python test.py
 - To run a specific set of test: python test.py test_name1 test_name2 etc
   - possible test names: authentication, database, documents, spawn, tool, tools, util, validate
-- To run all tests with error log output: python test.py log
-  - gives output as wanted for Travis CI
+- To run all tests with the pudb pytest plugin python test.py pudb
 """
 
 testing = True
@@ -86,8 +85,7 @@ def setup_tests(tests):
                         fig.TEST_USER,
                         'Test_SparCC',
                         fig.TEST_OTU,
-                        fig.TEST_CODE_OTU,
-                        testing)
+                        fig.TEST_CODE_OTU)
             assert 0 == upload_otu(test_otu)
             # Upload Lefse data if running test_tools.py
             test_lefse = (fig.TEST_SUBJECT_SHORT,
@@ -97,8 +95,7 @@ def setup_tests(tests):
                           fig.TEST_USER,
                           'Test_Lefse',
                           fig.TEST_LEFSE,
-                          fig.TEST_CODE_LEFSE,
-                          testing)
+                          fig.TEST_CODE_LEFSE)
             assert 0 == upload_lefse(test_lefse)
     if 'database' in tests:
         test_setup.append((fig.TEST_SUBJECT,
@@ -144,12 +141,12 @@ def setup_tests(tests):
         assert 0 == upload_metadata(setup)
 
 
-def run_tests(tests, log):
+def run_tests(tests, pudb):
     test_class = []
     for test in tests:
         test_class.append(test.capitalize() + 'Test')
     test_directory = Path(__file__).parent.resolve()
-    if log:
+    if pudb:
         run(['pytest', '--cov=mmeds', '--pudb', '-W', 'ignore::DeprecationWarning', '-W', 'ignore::FutureWarning',
              '-s', test_directory, '-x', '-k', ' or '.join(test_class), '--durations=0'], check=True)
     else:
@@ -168,8 +165,8 @@ def remove_users(users_added):
 def main():
     # Grab the arguments passed to the script, skipping the script itself
     tests = sys.argv[1:]
-    log = 'log' in tests
-    if log:
+    pudb = 'log' in tests
+    if pudb:
         tests.remove('log')
 
     setup = 'setup' in tests
@@ -190,7 +187,7 @@ def main():
         setup_tests(tests)
     if not setup:
         if not cleanup:
-            run_tests(tests, log)
+            run_tests(tests, pudb)
         remove_users(users_added)
 
 

--- a/mmeds/tests/unit/test.py
+++ b/mmeds/tests/unit/test.py
@@ -16,7 +16,7 @@ import mmeds.secrets as sec
   - gives output as wanted for Travis CI
 """
 
-testing = False
+testing = True
 
 
 def add_users(tests):

--- a/mmeds/tests/unit/test_spawn.py
+++ b/mmeds/tests/unit/test_spawn.py
@@ -99,6 +99,6 @@ class SpawnTests(TestCase):
 
     def test_d_node_analysis(self):
         for i in range(5):
-            self.q.put(('analysis', self.infos[0]['owner'], self.infos[0]['access_code'], 'test', '20', None, True, -1))
+            self.q.put(('analysis', fig.TEST_USER, 'test_spawn', 'test', '20', None, True, -1))
             result = self.pipe.recv()
         self.assertEqual(result, 'Analysis Not Started')

--- a/mmeds/tests/unit/test_spawn.py
+++ b/mmeds/tests/unit/test_spawn.py
@@ -91,7 +91,7 @@ class SpawnTests(TestCase):
     def test_c_restart_analysis(self):
         """ Test restarting the two analyses from their respective docs. """
         for proc in self.analyses:
-            self.q.put(('restart', proc['owner'], proc['access_code'], 1, -1))
+            self.q.put(('restart', proc['owner'], proc['access_code'], True, 1, -1))
             # Get the test tool
             self.pipe.recv()
         self.assertEqual(self.pipe.recv(), 0)

--- a/mmeds/tests/unit/test_spawn.py
+++ b/mmeds/tests/unit/test_spawn.py
@@ -96,3 +96,9 @@ class SpawnTests(TestCase):
             self.pipe.recv()
         self.assertEqual(self.pipe.recv(), 0)
         self.assertEqual(self.pipe.recv(), 0)
+
+    def test_d_node_analysis(self):
+        for i in range(5):
+            self.q.put(('analysis', self.infos[0]['owner'], self.infos[0]['access_code'], 'test', '20', None, True, -1))
+            result = self.pipe.recv()
+        self.assertEqual(result, 'Analysis Not Started')

--- a/mmeds/tests/unit/test_spawn.py
+++ b/mmeds/tests/unit/test_spawn.py
@@ -68,7 +68,7 @@ class SpawnTests(TestCase):
     def test_b_start_analysis(self):
         """ Test starting analysis through the queue """
         for proc in self.infos:
-            self.q.put(('analysis', proc['owner'], proc['access_code'], 'test', '20', None, -1))
+            self.q.put(('analysis', proc['owner'], proc['access_code'], 'test', '20', None, True, -1))
 
         sys.stderr.write('Waiting on analysis')
         # Check the analyses are started and running simultainiously

--- a/mmeds/tests/unit/test_tools.py
+++ b/mmeds/tests/unit/test_tools.py
@@ -26,7 +26,7 @@ class ToolsTests(TestCase):
 
     def run_qiime(self, code, tool_type, analysis_type, data_type, Qiime):
         qiime = Qiime(self.q, fig.TEST_USER, 'random_code', code, tool_type, analysis_type, self.config,
-                      testing=self.testing, analysis=False)
+                      on_node=True, testing=self.testing, analysis=False)
         logger.debug('Starting {}, id is {}'.format(qiime.name, id(qiime)))
         qiime.run()
         logger.debug('Ran {}'.format(qiime.name, id(qiime)))
@@ -59,7 +59,7 @@ class ToolsTests(TestCase):
     def test_qiime2_child_setup_analysis(self):
         config = load_config(Path(fig.TEST_CONFIG).read_text(), fig.TEST_METADATA)
         q2 = Qiime2(self.q, fig.TEST_USER, 'random_new_code', fig.TEST_CODE_SHORT, 'qiime2',
-                    'dada2', config, testing=self.testing, analysis=False)
+                    'dada2', config, testing=self.testing, on_node=True, analysis=False)
         q2.initial_setup()
         q2.setup_analysis()
         q2.create_children()
@@ -73,7 +73,7 @@ class ToolsTests(TestCase):
         return
         config = load_config(Path(fig.TEST_CONFIG).read_text(), fig.TEST_METADATA)
         q2 = Qiime2(self.q, fig.TEST_USER, 'SomeCodeHere', fig.TEST_CODE_SHORT, 'qiime2', 'dada2',
-                    config, testing=self.testing, analysis=False)
+                    config, testing=self.testing, on_node=True, analysis=False)
         q2.initial_setup()
         q2.setup_analysis()
         q2.create_analysis(Lefse)
@@ -82,7 +82,7 @@ class ToolsTests(TestCase):
     def test_sparcc_sub_analysis(self):
         config = load_config(Path(fig.TEST_CONFIG).read_text(), fig.TEST_METADATA)
         q2 = Qiime2(self.q, fig.TEST_USER, 'random_new_code', fig.TEST_CODE_SHORT, 'qiime2',
-                    'dada2', config, testing=self.testing, analysis=False)
+                    'dada2', config, testing=self.testing, on_node=True, analysis=False)
         q2.initial_setup()
         q2.setup_analysis()
         q2.queue_analysis('sparcc')

--- a/mmeds/tests/unit/test_tools.py
+++ b/mmeds/tests/unit/test_tools.py
@@ -26,7 +26,7 @@ class ToolsTests(TestCase):
 
     def run_qiime(self, code, tool_type, analysis_type, data_type, Qiime):
         qiime = Qiime(self.q, fig.TEST_USER, 'random_code', code, tool_type, analysis_type, self.config,
-                      on_node=True, testing=self.testing, analysis=False)
+                      run_on_node=True, testing=self.testing, analysis=False)
         logger.debug('Starting {}, id is {}'.format(qiime.name, id(qiime)))
         qiime.run()
         logger.debug('Ran {}'.format(qiime.name, id(qiime)))
@@ -59,7 +59,7 @@ class ToolsTests(TestCase):
     def test_qiime2_child_setup_analysis(self):
         config = load_config(Path(fig.TEST_CONFIG).read_text(), fig.TEST_METADATA)
         q2 = Qiime2(self.q, fig.TEST_USER, 'random_new_code', fig.TEST_CODE_SHORT, 'qiime2',
-                    'dada2', config, testing=self.testing, on_node=True, analysis=False)
+                    'dada2', config, testing=self.testing, run_on_node=True, analysis=False)
         q2.initial_setup()
         q2.setup_analysis()
         q2.create_children()
@@ -73,7 +73,7 @@ class ToolsTests(TestCase):
         return
         config = load_config(Path(fig.TEST_CONFIG).read_text(), fig.TEST_METADATA)
         q2 = Qiime2(self.q, fig.TEST_USER, 'SomeCodeHere', fig.TEST_CODE_SHORT, 'qiime2', 'dada2',
-                    config, testing=self.testing, on_node=True, analysis=False)
+                    config, testing=self.testing, run_on_node=True, analysis=False)
         q2.initial_setup()
         q2.setup_analysis()
         q2.create_analysis(Lefse)
@@ -82,7 +82,7 @@ class ToolsTests(TestCase):
     def test_sparcc_sub_analysis(self):
         config = load_config(Path(fig.TEST_CONFIG).read_text(), fig.TEST_METADATA)
         q2 = Qiime2(self.q, fig.TEST_USER, 'random_new_code', fig.TEST_CODE_SHORT, 'qiime2',
-                    'dada2', config, testing=self.testing, on_node=True, analysis=False)
+                    'dada2', config, testing=self.testing, run_on_node=True, analysis=False)
         q2.initial_setup()
         q2.setup_analysis()
         q2.queue_analysis('sparcc')

--- a/mmeds/tests/unit/test_tools.py
+++ b/mmeds/tests/unit/test_tools.py
@@ -26,7 +26,7 @@ class ToolsTests(TestCase):
 
     def run_qiime(self, code, tool_type, analysis_type, data_type, Qiime):
         qiime = Qiime(self.q, fig.TEST_USER, 'random_code', code, tool_type, analysis_type, self.config,
-                      run_on_node=True, testing=self.testing, analysis=False)
+                      self.testing, True, analysis=False)
         logger.debug('Starting {}, id is {}'.format(qiime.name, id(qiime)))
         qiime.run()
         logger.debug('Ran {}'.format(qiime.name, id(qiime)))
@@ -59,7 +59,7 @@ class ToolsTests(TestCase):
     def test_qiime2_child_setup_analysis(self):
         config = load_config(Path(fig.TEST_CONFIG).read_text(), fig.TEST_METADATA)
         q2 = Qiime2(self.q, fig.TEST_USER, 'random_new_code', fig.TEST_CODE_SHORT, 'qiime2',
-                    'dada2', config, testing=self.testing, run_on_node=True, analysis=False)
+                    'dada2', config, self.testing, True, analysis=False)
         q2.initial_setup()
         q2.setup_analysis()
         q2.create_children()
@@ -73,7 +73,7 @@ class ToolsTests(TestCase):
         return
         config = load_config(Path(fig.TEST_CONFIG).read_text(), fig.TEST_METADATA)
         q2 = Qiime2(self.q, fig.TEST_USER, 'SomeCodeHere', fig.TEST_CODE_SHORT, 'qiime2', 'dada2',
-                    config, testing=self.testing, run_on_node=True, analysis=False)
+                    config, self.testing, True, analysis=False)
         q2.initial_setup()
         q2.setup_analysis()
         q2.create_analysis(Lefse)
@@ -82,7 +82,7 @@ class ToolsTests(TestCase):
     def test_sparcc_sub_analysis(self):
         config = load_config(Path(fig.TEST_CONFIG).read_text(), fig.TEST_METADATA)
         q2 = Qiime2(self.q, fig.TEST_USER, 'random_new_code', fig.TEST_CODE_SHORT, 'qiime2',
-                    'dada2', config, testing=self.testing, run_on_node=True, analysis=False)
+                    'dada2', config, self.testing, True, analysis=False)
         q2.initial_setup()
         q2.setup_analysis()
         q2.queue_analysis('sparcc')

--- a/mmeds/tests/unit/test_tools.py
+++ b/mmeds/tests/unit/test_tools.py
@@ -92,5 +92,5 @@ class ToolsTests(TestCase):
         process = item
         self.assertSequenceEqual(process,
                                  ('analysis', q2.owner, q2.doc.access_code, 'sparcc',
-                                  q2.config['type'], q2.doc.config, q2.kill_stage))
+                                  q2.config['type'], q2.doc.config, True, q2.kill_stage))
         rmtree(q2.path)

--- a/mmeds/tools/lefse.py
+++ b/mmeds/tools/lefse.py
@@ -6,8 +6,8 @@ class Lefse(Tool):
     """ A class for LEfSe analysis of uploaded studies. """
 
     def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type,  config, testing,
-                 on_node, analysis=True, child=False, restart_stage=0, kill_stage=-1):
-        super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, on_node,
+                 run_on_node, analysis=True, child=False, restart_stage=0, kill_stage=-1):
+        super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, run_on_node,
                          analysis=analysis, child=child, restart_stage=restart_stage, kill_stage=kill_stage)
         load = 'module use {}/.modules/modulefiles; module load lefse;'.format(DATABASE_DIR.parent)
         self.jobtext.append(load)

--- a/mmeds/tools/lefse.py
+++ b/mmeds/tools/lefse.py
@@ -6,8 +6,8 @@ class Lefse(Tool):
     """ A class for LEfSe analysis of uploaded studies. """
 
     def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type,  config, testing,
-                 analysis=True, child=False, restart_stage=0, kill_stage=-1):
-        super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
+                 on_node, analysis=True, child=False, restart_stage=0, kill_stage=-1):
+        super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, on_node,
                          analysis=analysis, child=child, restart_stage=restart_stage, kill_stage=kill_stage)
         load = 'module use {}/.modules/modulefiles; module load lefse;'.format(DATABASE_DIR.parent)
         self.jobtext.append(load)

--- a/mmeds/tools/picrust1.py
+++ b/mmeds/tools/picrust1.py
@@ -5,10 +5,11 @@ from mmeds.tools.tool import Tool
 class PiCRUSt1(Tool):
     """ A class for SparCC analysis of uploaded studies. """
 
-    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
+    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, on_node,
                  analysis=True, restart_stage=0, kill_stage=-1, child=False):
         super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
-                         analysis=analysis, restart_stage=restart_stage, kill_stage=kill_stage, child=child)
+                         on_node=on_node, analysis=analysis, restart_stage=restart_stage, kill_stage=kill_stage,
+                         child=child)
         load = 'module use {}/.modules/modulefiles; module load picrust1;'.format(DATABASE_DIR.parent)
         self.jobtext.append(load)
         self.module = load

--- a/mmeds/tools/picrust1.py
+++ b/mmeds/tools/picrust1.py
@@ -5,10 +5,10 @@ from mmeds.tools.tool import Tool
 class PiCRUSt1(Tool):
     """ A class for SparCC analysis of uploaded studies. """
 
-    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, on_node,
+    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, run_on_node,
                  analysis=True, restart_stage=0, kill_stage=-1, child=False):
         super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
-                         on_node=on_node, analysis=analysis, restart_stage=restart_stage, kill_stage=kill_stage,
+                         run_on_node=run_on_node, analysis=analysis, restart_stage=restart_stage, kill_stage=kill_stage,
                          child=child)
         load = 'module use {}/.modules/modulefiles; module load picrust1;'.format(DATABASE_DIR.parent)
         self.jobtext.append(load)

--- a/mmeds/tools/qiime1.py
+++ b/mmeds/tools/qiime1.py
@@ -12,10 +12,11 @@ logger = MMEDSLog('debug').logger
 class Qiime1(Tool):
     """ A class for qiime 1.9.1 analysis of uploaded studies. """
 
-    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
+    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, on_node,
                  analysis=True, restart_stage=0, child=False, kill_stage=-1):
         super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
-                         analysis=analysis, restart_stage=restart_stage, kill_stage=kill_stage, child=child)
+                         on_node=on_node, analysis=analysis, restart_stage=restart_stage, kill_stage=kill_stage,
+                         child=child)
         load = 'module use {}/.modules/modulefiles; module load qiime/1.9.1;'.format(DATABASE_DIR.parent)
         self.jobtext.append(load)
         self.module = load

--- a/mmeds/tools/qiime1.py
+++ b/mmeds/tools/qiime1.py
@@ -12,10 +12,10 @@ logger = MMEDSLog('debug').logger
 class Qiime1(Tool):
     """ A class for qiime 1.9.1 analysis of uploaded studies. """
 
-    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, on_node,
+    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, run_on_node,
                  analysis=True, restart_stage=0, child=False, kill_stage=-1):
         super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
-                         on_node=on_node, analysis=analysis, restart_stage=restart_stage, kill_stage=kill_stage,
+                         run_on_node=run_on_node, analysis=analysis, restart_stage=restart_stage, kill_stage=kill_stage,
                          child=child)
         load = 'module use {}/.modules/modulefiles; module load qiime/1.9.1;'.format(DATABASE_DIR.parent)
         self.jobtext.append(load)

--- a/mmeds/tools/qiime1.py
+++ b/mmeds/tools/qiime1.py
@@ -12,8 +12,8 @@ logger = MMEDSLog('debug').logger
 class Qiime1(Tool):
     """ A class for qiime 1.9.1 analysis of uploaded studies. """
 
-    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, run_on_node,
-                 analysis=True, restart_stage=0, child=False, kill_stage=-1):
+    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
+                 run_on_node=False, analysis=True, restart_stage=0, child=False, kill_stage=-1):
         super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
                          run_on_node=run_on_node, analysis=analysis, restart_stage=restart_stage, kill_stage=kill_stage,
                          child=child)

--- a/mmeds/tools/qiime2.py
+++ b/mmeds/tools/qiime2.py
@@ -14,8 +14,8 @@ class Qiime2(Tool):
     # The default classifier for Q2 analysis
     classifier = DATABASE_DIR / 'gg-13-8-99-nb-classifier.qza'
 
-    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, run_on_node,
-                 analysis=True, restart_stage=0, kill_stage=-1, child=False):
+    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
+                 run_on_node=False, analysis=True, restart_stage=0, kill_stage=-1, child=False):
         super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
                          run_on_node=run_on_node, analysis=analysis, restart_stage=restart_stage,
                          kill_stage=kill_stage, child=child)

--- a/mmeds/tools/qiime2.py
+++ b/mmeds/tools/qiime2.py
@@ -14,10 +14,10 @@ class Qiime2(Tool):
     # The default classifier for Q2 analysis
     classifier = DATABASE_DIR / 'gg-13-8-99-nb-classifier.qza'
 
-    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
+    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, on_node,
                  analysis=True, restart_stage=0, kill_stage=-1, child=False):
         super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
-                         analysis=analysis, restart_stage=restart_stage,
+                         on_node=on_node, analysis=analysis, restart_stage=restart_stage,
                          kill_stage=kill_stage, child=child)
         load = 'module use {}/.modules/modulefiles; module load qiime2/2019.7;'.format(DATABASE_DIR.parent)
         self.module = load

--- a/mmeds/tools/qiime2.py
+++ b/mmeds/tools/qiime2.py
@@ -2,7 +2,7 @@ from subprocess import run
 from shutil import rmtree
 from pandas import read_csv
 
-from mmeds.config import STORAGE_DIR, DATABASE_DIR
+from mmeds.config import DATABASE_DIR
 from mmeds.util import log, setup_environment
 from mmeds.error import AnalysisError
 from mmeds.tools.tool import Tool
@@ -14,10 +14,10 @@ class Qiime2(Tool):
     # The default classifier for Q2 analysis
     classifier = DATABASE_DIR / 'gg-13-8-99-nb-classifier.qza'
 
-    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, on_node,
+    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, run_on_node,
                  analysis=True, restart_stage=0, kill_stage=-1, child=False):
         super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
-                         on_node=on_node, analysis=analysis, restart_stage=restart_stage,
+                         run_on_node=run_on_node, analysis=analysis, restart_stage=restart_stage,
                          kill_stage=kill_stage, child=child)
         load = 'module use {}/.modules/modulefiles; module load qiime2/2019.7;'.format(DATABASE_DIR.parent)
         self.module = load

--- a/mmeds/tools/sparcc.py
+++ b/mmeds/tools/sparcc.py
@@ -5,10 +5,11 @@ from mmeds.tools.tool import Tool
 class SparCC(Tool):
     """ A class for SparCC analysis of uploaded studies. """
 
-    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
+    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, on_node,
                  analysis=True, restart_stage=0, kill_stage=-1, child=False):
         super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
-                         analysis=analysis, restart_stage=restart_stage, kill_stage=kill_stage, child=child)
+                         on_node=on_node, analysis=analysis, restart_stage=restart_stage,
+                         kill_stage=kill_stage, child=child)
         load = 'module use {}/.modules/modulefiles; module load sparcc;'.format(DATABASE_DIR.parent)
         self.jobtext.append(load)
         self.module = load

--- a/mmeds/tools/sparcc.py
+++ b/mmeds/tools/sparcc.py
@@ -5,10 +5,10 @@ from mmeds.tools.tool import Tool
 class SparCC(Tool):
     """ A class for SparCC analysis of uploaded studies. """
 
-    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, on_node,
+    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, run_on_node,
                  analysis=True, restart_stage=0, kill_stage=-1, child=False):
         super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
-                         on_node=on_node, analysis=analysis, restart_stage=restart_stage,
+                         run_on_node=run_on_node, analysis=analysis, restart_stage=restart_stage,
                          kill_stage=kill_stage, child=child)
         load = 'module use {}/.modules/modulefiles; module load sparcc;'.format(DATABASE_DIR.parent)
         self.jobtext.append(load)

--- a/mmeds/tools/tool.py
+++ b/mmeds/tools/tool.py
@@ -558,8 +558,9 @@ class Tool(mp.Process):
                 self.logger.debug([child.name for child in self.children])
 
             self.update_doc(analysis_status='started')
-            if self.testing or self.config['run_on_node']:
+            if self.testing or self.run_on_node:
                 self.logger.debug('I {} am about to run'.format(self.name))
+                jobfile.chmod(0o770)
                 # Send the output to the error log
                 with open(self.get_file('errorlog', True), 'w+', buffering=1) as f:
                     # Run the command

--- a/mmeds/tools/tool.py
+++ b/mmeds/tools/tool.py
@@ -347,7 +347,7 @@ class Tool(mp.Process):
         :tool_type: The type of tool to spawn
         """
         self.queue.put(('analysis', self.owner, self.doc.access_code, tool_type,
-                        self.config['type'], self.doc.config, self.on_node, self.kill_stage))
+                        self.config['type'], self.doc.config, self.run_on_node, self.kill_stage))
 
     def child_setup(self):
         # Update process name and children

--- a/mmeds/tools/tool.py
+++ b/mmeds/tools/tool.py
@@ -31,7 +31,7 @@ class Tool(mp.Process):
     """
 
     def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
-                 on_node, threads=10, analysis=True, child=False, restart_stage=0, kill_stage=-1):
+                 run_on_node, threads=10, analysis=True, child=False, restart_stage=0, kill_stage=-1):
         """
         Setup the Tool class
         ====================
@@ -58,7 +58,7 @@ class Tool(mp.Process):
         self.owner = owner
         self.analysis = analysis
         self.module = None
-        self.run_on_node = on_node
+        self.run_on_node = run_on_node
         self.restart_stage = restart_stage
         self.current_stage = -2
         self.stage_files = defaultdict(list)
@@ -678,9 +678,9 @@ class Tool(mp.Process):
 class TestTool(Tool):
     """ A class for running tool methods during testing """
 
-    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, on_node,
+    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, run_on_node,
                  analysis=True, restart_stage=0, kill_stage=-1, time=20):
-        super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, on_node,
+        super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, run_on_node,
                          analysis=analysis, restart_stage=restart_stage)
         print('Creating test tool with restart stage {} and time {}'.format(restart_stage, time))
         self.time = time

--- a/mmeds/tools/tool.py
+++ b/mmeds/tools/tool.py
@@ -19,9 +19,6 @@ from mmeds.log import MMEDSLog
 import multiprocessing as mp
 import os
 
-import multiprocessing_logging as mpl
-mpl.install_mp_handler()
-
 
 class Tool(mp.Process):
     """

--- a/mmeds/tools/tool.py
+++ b/mmeds/tools/tool.py
@@ -678,9 +678,9 @@ class Tool(mp.Process):
 class TestTool(Tool):
     """ A class for running tool methods during testing """
 
-    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
+    def __init__(self, queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, on_node,
                  analysis=True, restart_stage=0, kill_stage=-1, time=20):
-        super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing,
+        super().__init__(queue, owner, access_code, parent_code, tool_type, analysis_type, config, testing, on_node,
                          analysis=analysis, restart_stage=restart_stage)
         print('Creating test tool with restart stage {} and time {}'.format(restart_stage, time))
         self.time = time

--- a/mmeds/util.py
+++ b/mmeds/util.py
@@ -15,7 +15,7 @@ import yaml
 import mmeds.config as fig
 import pandas as pd
 
-logger = MMEDSLog('debug').logger
+logger = MMEDSLog('util-debug').logger
 
 
 ###########

--- a/mmeds/util.py
+++ b/mmeds/util.py
@@ -820,6 +820,7 @@ def debug_log(text, testing=False):
 def info_log(text, testing=False):
     log(text, testing=testing, log_type='Info')
 
+
 def parse_code_blocks(path):
     # Load the code templates
     data = Path(path).read_text().split('\n=====\n')
@@ -878,6 +879,12 @@ def send_email(toaddr, user, message='upload', testing=False, **kwargs):
                'If you did not do this contact us immediately.\n\nBest,\nMmeds Team\n\n' +\
                'If you have any issues please email: {cemail} with a description of your problem.\n'
         subject = 'Error During Analysis'
+    elif message == 'too_many_on_node':
+        body = 'Hello {user},\nThere was an issue starting requested {analysis} analysis.\n' +\
+               'There are too many analyses already running on the main node.\n' +\
+               'Either submit a new analysis to the queue or wait until others finish.\n\nBest,\nMmeds Team\n\n' +\
+               'If you have any issues please email: {cemail} with a description of your problem.\n'
+        subject = 'Analysis Not Started'
 
     email_body = body.format(
         user=user,

--- a/mmeds/validate.py
+++ b/mmeds/validate.py
@@ -11,11 +11,7 @@ from datetime import datetime
 from mmeds.log import MMEDSLog
 
 
-import multiprocessing_logging as mpl
-mpl.install_mp_handler()
-
-
-logger = MMEDSLog('error').logger
+logger = MMEDSLog('validate-error').logger
 
 NAs = ['n/a', 'n.a.', 'n_a', 'na', 'N/A', 'N.A.', 'N_A']
 


### PR DESCRIPTION
# Pull Request Template for MMEDS
closes #206 
Added the functionality for a user with elevated privileges to request to run analyses directly on the node rather than submitting them to the queue. This is limited to four analyses at a time so as not to run out of resources on the node.
## What has changed
mmeds/spawn.py, mmeds/tools/*: This affects several files. There is a new parameter `run_on_node` that gets put in the spawn queue and subsequently is passed to the Tool (sub)class
mmeds/error.py: Added a privilege error to be thrown should someone without privileges alter the webpage to request running analysis on the node
## Checklist of pre-requisites
-   [x] Does the code run?  
-   [x] Does the code follow the repository style?  
-   [x] Is the code tested?  

## How to use the feature
Example: To do X run new function Y with parameters A, B, and C which gives result Z.

## How the design has changed
Example: Functions A, B, and C are now all methods of Class D.

## Additional notes
