### PR TITLE
Automatic weight updates

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,10 +3,11 @@ exclude_lines =
     if __name__ == "__main__":
 
 [run]
+include = */mmeds/*
 omit =
-    **/__init__.py
     setup.py
     mmeds/tests/**
+    scripts/**
     ~/.modules/**
     **/modules/**
     **/bad**

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,6 @@ jobs:
         run: |
           coverage run --parallel-mode --concurrency=multiprocessing ./mmeds/host/manager.py&
           coverage run --parallel-mode --concurrency=multiprocessing ./mmeds/tests/unit/test.py;
-      - name: Combine Coverage
-        run: coverage combine
       - name: Upload Unit coverage
         run: bash <(curl -s https://codecov.io/bash) -cF unit;
       - name: Server Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,8 @@ jobs:
         run: |
           coverage run --parallel-mode --concurrency=multiprocessing ./mmeds/host/manager.py&
           coverage run --parallel-mode --concurrency=multiprocessing ./mmeds/tests/unit/test.py;
+      - name: Combine Coverage
+        run: coverage combine
       - name: Upload Unit coverage
         run: bash <(curl -s https://codecov.io/bash) -cF unit;
       - name: Server Tests

--- a/mmeds/tests/unit/test.py
+++ b/mmeds/tests/unit/test.py
@@ -151,7 +151,7 @@ def run_tests(tests, pudb):
         run(['pytest', '--cov=mmeds', '--pudb', '-W', 'ignore::DeprecationWarning', '-W', 'ignore::FutureWarning',
              '-s', test_directory, '-x', '-k', ' or '.join(test_class), '--durations=0'], check=True)
     else:
-        run(['pytest', '-W', 'ignore::DeprecationWarning', '-W',
+        run(['pytest', '--cov=mmeds', '-W', 'ignore::DeprecationWarning', '-W',
              'ignore::FutureWarning', test_directory, '-k', ' or '.join(test_class), '--durations=0'], check=True)
 
 

--- a/mmeds/tests/unit/test.py
+++ b/mmeds/tests/unit/test.py
@@ -189,7 +189,8 @@ def main():
             'util',
             'validate',
             'formatter',
-            'adder'
+            'adder',
+            'uploader'
         ]
 
     users_added = add_users(tests)

--- a/mmeds/tests/unit/test.py
+++ b/mmeds/tests/unit/test.py
@@ -151,7 +151,7 @@ def run_tests(tests, pudb):
         run(['pytest', '--cov=mmeds', '--pudb', '-W', 'ignore::DeprecationWarning', '-W', 'ignore::FutureWarning',
              '-s', test_directory, '-x', '-k', ' or '.join(test_class), '--durations=0'], check=True)
     else:
-        run(['pytest', '--cov=mmeds', '-W', 'ignore::DeprecationWarning', '-W',
+        run(['pytest', '-W', 'ignore::DeprecationWarning', '-W',
              'ignore::FutureWarning', test_directory, '-k', ' or '.join(test_class), '--durations=0'], check=True)
 
 

--- a/mmeds/tests/unit/test_uploader.py
+++ b/mmeds/tests/unit/test_uploader.py
@@ -1,0 +1,31 @@
+from mmeds.database.database import upload_otu
+from mmeds.authentication import add_user, remove_user
+import mmeds.config as fig
+from unittest import TestCase
+
+testing = True
+
+
+class UploaderTests(TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        self.user = 'Upload_User'
+        self.test_code = 'ThisIsATest'
+        add_user(self.user, 'uploads', 'na@na.com', testing=testing)
+
+        self.test_otu = (fig.TEST_SUBJECT_SHORT,
+                         'human',
+                         fig.TEST_SPECIMEN_SHORT,
+                         fig.TEST_DIR,
+                         self.user,
+                         'Test_Uploader',
+                         fig.TEST_OTU,
+                         self.test_code)
+
+    @classmethod
+    def tearDownClass(self):
+        remove_user(self.user, testing=testing)
+
+    def test_uploader(self):
+        assert 0 == upload_otu(self.test_otu)

--- a/setup.sql
+++ b/setup.sql
@@ -7,3 +7,4 @@ source sql/users.sql;
 source sql/protected_views.sql;
 source sql/null_entries.sql;
 source sql/views.sql;
+source sql/triggers.sql;

--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -6,11 +6,15 @@ CREATE TRIGGER specimen_weight_update
 AFTER INSERT ON Aliquot
 FOR EACH ROW
 BEGIN
--- Get the current weight of the associated Specimen
--- NEW is a temporary table containing the data from the INSERT call
-SELECT SpecimenWeight INTO @CurrentSpecimenWeight FROM Specimen WHERE idSpecimen = NEW.Specimen_idSpecimen;
--- Subject the weight of the new Aliquot from the Specimen
-UPDATE Specimen SET SpecimenWeight = @CurrentSpecimenWeight - NEW.AliquotWeight WHERE idSpecimen = NEW.Specimen_idSpecimen;
+    -- Don't fire the trigger when this variable is disabled
+    IF (@DISABLE_TRIGGERS = FALSE)
+    THEN
+        -- Get the current weight of the associated Specimen
+        -- NEW is a temporary table containing the data from the INSERT call
+        SELECT SpecimenWeight INTO @CurrentSpecimenWeight FROM Specimen WHERE idSpecimen = NEW.Specimen_idSpecimen;
+        -- Subject the weight of the new Aliquot from the Specimen
+        UPDATE Specimen SET SpecimenWeight = @CurrentSpecimenWeight - NEW.AliquotWeight WHERE idSpecimen = NEW.Specimen_idSpecimen;
+    END IF;
 END //
 
 
@@ -20,11 +24,14 @@ CREATE TRIGGER aliquot_weight_update
 AFTER INSERT ON Sample
 FOR EACH ROW
 BEGIN
--- Get the current weight of the associated Specimen
--- NEW is a temporary table containing the data from the INSERT call
-SELECT AliquotWeight INTO @CurrentAliquotWeight FROM Aliquot WHERE `idAliquot` = `NEW`.`Aliquot_idAliquot`;
--- Subject the weight of the new Sample from the Aliquot
-UPDATE Aliquot SET AliquotWeight = @CurrentAliquotWeight - NEW.`SampleWeight` WHERE `idAliquot` = `NEW`.`Aliquot_idAliquot`;
+    IF (@DISABLE_TRIGGERS = FALSE)
+    THEN
+        -- Get the current weight of the associated Specimen
+        -- NEW is a temporary table containing the data from the INSERT call
+        SELECT AliquotWeight INTO @CurrentAliquotWeight FROM Aliquot WHERE `idAliquot` = `NEW`.`Aliquot_idAliquot`;
+        -- Subject the weight of the new Sample from the Aliquot
+        UPDATE Aliquot SET AliquotWeight = @CurrentAliquotWeight - NEW.`SampleWeight` WHERE `idAliquot` = `NEW`.`Aliquot_idAliquot`;
+END IF;
 END //
 
 DELIMITER ;

--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -1,0 +1,30 @@
+DELIMITER //
+
+DROP TRIGGER IF EXISTS specimen_weight_update //
+
+CREATE TRIGGER specimen_weight_update
+AFTER INSERT ON Aliquot
+FOR EACH ROW
+BEGIN
+-- Get the current weight of the associated Specimen
+-- NEW is a temporary table containing the data from the INSERT call
+SELECT SpecimenWeight INTO @CurrentSpecimenWeight FROM Specimen WHERE idSpecimen = NEW.Specimen_idSpecimen;
+-- Subject the weight of the new Aliquot from the Specimen
+UPDATE Specimen SET SpecimenWeight = @CurrentSpecimenWeight - NEW.AliquotWeight WHERE idSpecimen = NEW.Specimen_idSpecimen;
+END //
+
+
+DROP TRIGGER IF EXISTS aliquot_weight_update //
+
+CREATE TRIGGER aliquot_weight_update
+AFTER INSERT ON Sample
+FOR EACH ROW
+BEGIN
+-- Get the current weight of the associated Specimen
+-- NEW is a temporary table containing the data from the INSERT call
+SELECT AliquotWeight INTO @CurrentAliquotWeight FROM Aliquot WHERE `idAliquot` = `NEW`.`Aliquot_idAliquot`;
+-- Subject the weight of the new Sample from the Aliquot
+UPDATE Aliquot SET AliquotWeight = @CurrentAliquotWeight - NEW.`SampleWeight` WHERE `idAliquot` = `NEW`.`Aliquot_idAliquot`;
+END //
+
+DELIMITER ;


### PR DESCRIPTION
# Pull Request Template for MMEDS
Closes #261 
## What has changed
Include each file that was changed, how it was changed (in broad terms), and why it was changed.
New file
`sql/triggers.sql`: Contains two triggers, defined for the Specimen and Aliquot Tables. They fire when an insert statement is called on the Aliquot and Sample tables respectively. There is a Session variable `@DISABLE_TRIGGERS` that can be set to false to disable them. 
Modified:
`mmeds/database/metadata_uploader.py`: Added calls to disable triggers before performing the metadata imports.

## Checklist of pre-requisites
-   [x] Does the code run?  
-   [x] Does the code follow the repository style?  
-   [x] Is the code tested?  

## How to use the feature
Example: To do X run new function Y with parameters A, B, and C which gives result Z.

## How the design has changed
Example: Functions A, B, and C are now all methods of Class D.

## Additional notes
