### PR TITLE
Enhancement summary coloring

### DIFF
--- a/mmeds/config.py
+++ b/mmeds/config.py
@@ -593,9 +593,9 @@ COL_TO_TABLE = {}
 
 # Summary Gradient Colors for use in continuous variable plots
 CONTINUOUS_GRADIENTS = [
-    ("0000FF", "FF0000"),
-    ("FF9900", "9900CC"),
-    ("00FFFF", "FF33CC")
+    ("0000FF", "FF0000"), # Blue - Red
+    ("FF9900", "9900CC"), # Orange - Purple
+    ("00FFFF", "FF33CC")  # Cyan - Pink
 ]
 
 # Try connecting via the testing setup

--- a/mmeds/config.py
+++ b/mmeds/config.py
@@ -591,6 +591,13 @@ COLUMN_TYPES_SUBJECT = defaultdict(dict)
 COLUMN_TYPES_ANIMAL_SUBJECT = defaultdict(dict)
 COL_TO_TABLE = {}
 
+# Summary Gradient Colors for use in continuous variable plots
+CONTINUOUS_GRADIENTS = [
+    ("0000FF", "FFFFFF", "FF0000"),
+    ("FF9900", "FFFFFF", "9900CC"),
+    ("FF33CC", "FFFFFF", "00E600")
+]
+
 # Try connecting via the testing setup
 if IS_PRODUCTION or TESTING:
     try:
@@ -661,8 +668,8 @@ if IS_PRODUCTION or TESTING:
     }
 
     for test_file, col_types, tables in [(TEST_SPECIMEN, COLUMN_TYPES_SPECIMEN, SPECIMEN_TABLES),
-                                        (TEST_SUBJECT, COLUMN_TYPES_SUBJECT, SUBJECT_TABLES),
-                                        (TEST_ANIMAL_SUBJECT, COLUMN_TYPES_ANIMAL_SUBJECT, ANIMAL_SUBJECT_TABLES)]:
+                                         (TEST_SUBJECT, COLUMN_TYPES_SUBJECT, SUBJECT_TABLES),
+                                         (TEST_ANIMAL_SUBJECT, COLUMN_TYPES_ANIMAL_SUBJECT, ANIMAL_SUBJECT_TABLES)]:
         tdf = read_csv(test_file,
                        sep='\t',
                        header=[0, 1],

--- a/mmeds/config.py
+++ b/mmeds/config.py
@@ -593,9 +593,9 @@ COL_TO_TABLE = {}
 
 # Summary Gradient Colors for use in continuous variable plots
 CONTINUOUS_GRADIENTS = [
-    ("0000FF", "FFFFFF", "FF0000"),
-    ("FF9900", "FFFFFF", "9900CC"),
-    ("FF33CC", "FFFFFF", "00E600")
+    ("0000FF", "FF0000"),
+    ("FF9900", "9900CC"),
+    ("00FFFF", "FF33CC")
 ]
 
 # Try connecting via the testing setup

--- a/mmeds/resources/summary_code.txt
+++ b/mmeds/resources/summary_code.txt
@@ -30,22 +30,12 @@ metadata_continuous = sorted([x for x in config['metadata'] if config['metadata_
 
 # Stores a list of values shared accross groups but unique within (for graphing)
 max_colors = 0
-max_colors_con = 0
 # Create information for R color palettes
-for group_name in metadata_columns:
+for group_name in metadata_discrete:
     if group_name in mdf and not mdf[group_name].isnull().all():
         grouping = mdf[group_name]
-        uni = grouping.nunique()
-        if config['metadata_continuous'][group_name]:
-            # Get the category with the most colors to use for palette creation
-            if uni > max_colors_con:
-                max_colors_con = uni
-        else:
-            # Get the category with the most colors to use for palette creation
-            if uni > max_colors:
-                max_colors = uni
+        max_colors += grouping.nunique()
 
-all_colors_con = ['con{{}}'.format(i) for i in range(max_colors_con)]
 all_colors = ['color{{}}'.format(i) for i in range(max_colors)]
 
 # Load the extention for jupyter
@@ -53,41 +43,35 @@ all_colors = ['color{{}}'.format(i) for i in range(max_colors)]
 =====
 py_setup_2<source>
 color_maps = {}
-for group_name in metadata_columns:
+color_max = 0
+for group_name in metadata_discrete:
     if not mdf[group_name].isnull().all():
         grouping = mdf[group_name]
-        uni = grouping.nunique() # Unique values in the column
-        if config['metadata_continuous'][group_name]:
-            inc = floor(max_colors_con / uni) # Increment to advance the color assignments
-            color_maps[group_name] = {str(x):'con{}'.format(i * inc)
-                                      for i,x in enumerate(grouping.drop_duplicates())}
-        else:
-            inc = floor(max_colors / uni) # Increment to advance the color assignments
-            color_maps[group_name] = {str(x):'color{}'.format(i * inc)
-                                      for i, x in enumerate(grouping.drop_duplicates())}
+        color_maps[group_name] = {str(x):'color{}'.format(color_max + i)
+                                      for i, x in enumerate(grouping.drop_duplicates())} 
+        color_max += grouping.nunique() # Unique grouping vals
 =====
 r_setup<source>
-%%R -i all_colors -i all_colors_con -o allRGB
+%%R -i all_colors -o allRGB
 library(ggplot2)
 library(RColorBrewer)
 library(GGally)
 library(ggrepel)
 
 # Create custom color palette
-myColors <- brewer.pal(11, "Paired")
-colorMaker <- colorRampPalette(myColors)
-allColorsDisc <- colorMaker(length(unique(all_colors)))
-# Custom continuous(ish) color palette
-myColorsCon <- brewer.pal(11, "Spectral")
-colorMakerCon <- colorRampPalette(myColorsCon)
-allColorsCon <- colorMakerCon(length(unique(all_colors_con)))
+myColors <- brewer.pal(8, "Set1")
+if (length(myColors) > length(unique(all_colors))) {
+    allColors <- myColors[0 : length(unique(all_colors))]
+}
+else {
+    colorMaker <- colorRampPalette(myColors)
+    allColors <- colorMaker(length(unique(all_colors)))
+}
 
 # Rename the colors to match with the groups
-names(allColorsDisc) <- all_colors
-names(allColorsCon) <- all_colors_con
+names(allColors) <- all_colors
 
 # Create the objects for graphing with the colors
-allColors <- append(allColorsDisc, allColorsCon)
 colScale <- scale_color_manual(name = ~GroupID, values = allColors)
 colFill <- scale_fill_manual(name = ~GroupID, values = allColors)
 
@@ -352,10 +336,6 @@ for group_name in metadata_continuous:
     agger = {{'Error': 'sem', 'value': 'mean'}}
     group = groups.groupby([group_name, 'variable']).agg(agger).reset_index()
 
-    # Assign information for the colors
-    colors = [color_maps[group_name][str(x)] for x in group[group_name]]
-    group = group.assign(GroupID=colors)
-
     # Assign information for grouping
     group_names = [group_name for x in group[group_name]]
     group = group.assign(GroupName=group_names)
@@ -373,7 +353,6 @@ df = pd.concat(group_means, axis=0, sort=False)
 df.SamplingDepth = df.SamplingDepth.astype(float)
 df.Error = df.Error.astype(float)
 df.AverageValue = df.AverageValue.astype(float)
-df.GroupID = df.GroupID.astype(str)
 df.GroupName = df.GroupName.astype(str)
 =====
 alpha_r<source>
@@ -474,7 +453,7 @@ for(i in 1:p$nrow) {{
                                 p[i, j]$labels$x,
                                 p[i, j]$labels$y)
             png(filename, width = 6, height = 6, unit='in', res=200)
-            sp <- p[i,j] + geom_text_repel(color = "black", alpha = 0.6, max.overlaps = Inf) +
+            sp <- p[i,j] + geom_text_repel(color = "black", alpha = 0.35, max.overlaps = Inf) +
                       theme(legend.position = 'none',
                             plot.title = element_text(hjust = 0.5),
                             plot.subtitle = element_text(hjust = 0.5)) +

--- a/mmeds/resources/summary_code.txt
+++ b/mmeds/resources/summary_code.txt
@@ -35,6 +35,7 @@ for group_name in metadata_discrete:
     if group_name in mdf and not mdf[group_name].isnull().all():
         grouping = mdf[group_name]
         max_colors += grouping.nunique()
+        # Total number of discrete colors == number of discrete values across all vars
 
 all_colors = ['color{{}}'.format(i) for i in range(max_colors)]
 
@@ -42,6 +43,7 @@ all_colors = ['color{{}}'.format(i) for i in range(max_colors)]
 %load_ext rpy2.ipython
 =====
 py_setup_2<source>
+# Assign colors to discrete values
 color_maps = {}
 color_max = 0
 for group_name in metadata_discrete:
@@ -58,12 +60,12 @@ library(RColorBrewer)
 library(GGally)
 library(ggrepel)
 
-# Create custom color palette
+# Create custom color palette from brewer "Set1"
 myColors <- brewer.pal(8, "Set1")
-if (length(myColors) > length(unique(all_colors))) {
+if (length(myColors) >= length(unique(all_colors))) {
     allColors <- myColors[0 : length(unique(all_colors))]
-}
-else {
+} 
+else { # Greater than 8 colors, extrapolate to get more
     colorMaker <- colorRampPalette(myColors)
     allColors <- colorMaker(length(unique(all_colors)))
 }

--- a/mmeds/resources/summary_code.txt
+++ b/mmeds/resources/summary_code.txt
@@ -28,14 +28,12 @@ metadata_columns = sorted(config['metadata'])
 metadata_discrete = sorted([x for x in config['metadata'] if not config['metadata_continuous'][x]])
 metadata_continuous = sorted([x for x in config['metadata'] if config['metadata_continuous'][x]])
 
-# Stores a list of values shared accross groups but unique within (for graphing)
+# Calculate needed number of discrete colors, equal to the number of values across all discrete variables
 max_colors = 0
-# Create information for R color palettes
 for group_name in metadata_discrete:
     if group_name in mdf and not mdf[group_name].isnull().all():
         grouping = mdf[group_name]
         max_colors += grouping.nunique()
-        # Total number of discrete colors == number of discrete values across all vars
 
 all_colors = ['color{{}}'.format(i) for i in range(max_colors)]
 
@@ -62,10 +60,11 @@ library(ggrepel)
 
 # Create custom color palette from brewer "Set1"
 myColors <- brewer.pal(8, "Set1")
+
+# Extrapolate extra colors only if number of vars exceeds the number of colors in the initial palette
 if (length(myColors) >= length(unique(all_colors))) {
     allColors <- myColors[0 : length(unique(all_colors))]
-} 
-else { # Greater than 8 colors, extrapolate to get more
+} else {
     colorMaker <- colorRampPalette(myColors)
     allColors <- colorMaker(length(unique(all_colors)))
 }

--- a/mmeds/resources/summary_code.txt
+++ b/mmeds/resources/summary_code.txt
@@ -409,7 +409,7 @@ p <- ggplot(data = df.var, aes(x = {xaxis}, y = AverageValue, color = Grouping,g
       theme_bw() +
       theme(legend.position = 'bottom',
             plot.title = element_text(hjust = 0.5),
-            plot.subtitle = element_text(hjust = 0.5)) + scale_color_gradient2(low="#{low}", high="#{high}", mid="#{mid}", midpoint=mean(df.var$Grouping, na.rm=TRUE), name = '{cat}', space = "Lab", na.value = "#888888", guide = "colorbar", aesthetics = "color")
+            plot.subtitle = element_text(hjust = 0.5)) + scale_color_gradient(low="#{low}", high="#{high}", name = '{cat}', space = "Lab", na.value = "#888888", guide = "colorbar", aesthetics = "color")
 
 # Save plots
 ggsave('{file1}', height = 6, width = 6)
@@ -521,14 +521,14 @@ p <- ggpairs(df[,c(1:3)],
              legend = 4,
              upper = list(continuous = "points", combo = "box_no_facet"),
              lower = list(continuous = "points", combo = "dot_no_facet"),
-             aes(color = df$variable, label = rownames(df))) +
+             aes(color = df$variable, label = rownames(df)), alpha = 1.0) +
          theme_bw() +
          theme(legend.position = 'bottom',
                plot.title = element_text(hjust = 0.5),
                plot.subtitle = element_text(hjust = 0.5)) +
          labs(title = 'PCA plot',
               subtitle = 'Colored by {cat}') +
-         scale_color_gradient2(low="#{low}", high="#{high}", mid="#{mid}", midpoint=mean(df$variable, na.rm=TRUE), name = '{cat}', space = "Lab", na.value = "#888888", guide = "colorbar", aesthetics = "color")
+         scale_color_gradient(low="#{low}", high="#{high}", name = '{cat}', space = "Lab", na.value = "#888888", guide = "colorbar", aesthetics = "color")
 
 print(p)
 out <- dev.off()
@@ -543,7 +543,7 @@ for(i in 1:p$nrow) {{
                                 p[i, j]$labels$x,
                                 p[i, j]$labels$y)
             png(filename, width = 6, height = 6, unit='in', res=200)
-            sp <- p[i,j] + geom_text_repel(color = "black", alpha = 0.6, max.overlaps = Inf) +
+            sp <- p[i,j] + geom_text_repel(color = "black", alpha = 0.35, max.overlaps = Inf) +
                       theme(legend.position = 'bottom',
                             plot.title = element_text(hjust = 0.5),
                             plot.subtitle = element_text(hjust = 0.5)) +
@@ -551,7 +551,7 @@ for(i in 1:p$nrow) {{
                                            p[i, j]$labels$x,
                                            p[i, j]$labels$y),
                            subtitle = 'Colored by {cat}') +
-                      scale_color_gradient2(low="#{low}", high="#{high}", mid="#{mid}", midpoint=mean(df$variable, na.rm=TRUE), name = '{cat}', space = "Lab", na.value = "#888888", guide = "colorbar", aesthetics = "color")
+                      scale_color_gradient(low="#{low}", high="#{high}", name = '{cat}', space = "Lab", na.value = "#888888", guide = "colorbar", aesthetics = "color")
             print(sp)
             out <- dev.off()
         }}

--- a/mmeds/resources/summary_code.txt
+++ b/mmeds/resources/summary_code.txt
@@ -409,7 +409,7 @@ p <- ggplot(data = df.var, aes(x = {xaxis}, y = AverageValue, color = Grouping,g
       theme_bw() +
       theme(legend.position = 'bottom',
             plot.title = element_text(hjust = 0.5),
-            plot.subtitle = element_text(hjust = 0.5)) + scale_color_gradient2(low="#0000FF", high="#FF0000", mid="#FFFFFF", midpoint=mean(df.var$Grouping, na.rm=TRUE), name = '{cat}', space = "Lab", na.value = "#888888", guide = "colorbar", aesthetics = "color")
+            plot.subtitle = element_text(hjust = 0.5)) + scale_color_gradient2(low="#{low}", high="#{high}", mid="#{mid}", midpoint=mean(df.var$Grouping, na.rm=TRUE), name = '{cat}', space = "Lab", na.value = "#888888", guide = "colorbar", aesthetics = "color")
 
 # Save plots
 ggsave('{file1}', height = 6, width = 6)
@@ -474,7 +474,7 @@ for(i in 1:p$nrow) {{
                                 p[i, j]$labels$x,
                                 p[i, j]$labels$y)
             png(filename, width = 6, height = 6, unit='in', res=200)
-            sp <- p[i,j] + geom_text_repel(max.overlaps = Inf) +
+            sp <- p[i,j] + geom_text_repel(color = "black", alpha = 0.6, max.overlaps = Inf) +
                       theme(legend.position = 'none',
                             plot.title = element_text(hjust = 0.5),
                             plot.subtitle = element_text(hjust = 0.5)) +
@@ -528,7 +528,7 @@ p <- ggpairs(df[,c(1:3)],
                plot.subtitle = element_text(hjust = 0.5)) +
          labs(title = 'PCA plot',
               subtitle = 'Colored by {cat}') +
-         scale_color_gradient2(low="#0000FF", high="#FF0000", mid="#FFFFFF", midpoint=mean(df$variable, na.rm=TRUE), name = '{cat}', space = "Lab", na.value = "#888888", guide = "colorbar", aesthetics = "color")
+         scale_color_gradient2(low="#{low}", high="#{high}", mid="#{mid}", midpoint=mean(df$variable, na.rm=TRUE), name = '{cat}', space = "Lab", na.value = "#888888", guide = "colorbar", aesthetics = "color")
 
 print(p)
 out <- dev.off()
@@ -543,7 +543,7 @@ for(i in 1:p$nrow) {{
                                 p[i, j]$labels$x,
                                 p[i, j]$labels$y)
             png(filename, width = 6, height = 6, unit='in', res=200)
-            sp <- p[i,j] + geom_text_repel(max.overlaps = Inf) +
+            sp <- p[i,j] + geom_text_repel(color = "black", alpha = 0.6, max.overlaps = Inf) +
                       theme(legend.position = 'bottom',
                             plot.title = element_text(hjust = 0.5),
                             plot.subtitle = element_text(hjust = 0.5)) +
@@ -551,7 +551,7 @@ for(i in 1:p$nrow) {{
                                            p[i, j]$labels$x,
                                            p[i, j]$labels$y),
                            subtitle = 'Colored by {cat}') +
-                      scale_color_gradient2(low="#0000FF", high="#FF0000", mid="#FFFFFF", midpoint=mean(df$variable, na.rm=TRUE), name = '{cat}', space = "Lab", na.value = "#888888", guide = "colorbar", aesthetics = "color")
+                      scale_color_gradient2(low="#{low}", high="#{high}", mid="#{mid}", midpoint=mean(df$variable, na.rm=TRUE), name = '{cat}', space = "Lab", na.value = "#888888", guide = "colorbar", aesthetics = "color")
             print(sp)
             out <- dev.off()
         }}

--- a/mmeds/summary.py
+++ b/mmeds/summary.py
@@ -346,8 +346,7 @@ class MMEDSNotebook():
                     xaxis=xaxis,
                     cat=col,
                     low=CONTINUOUS_GRADIENTS[gradient_index][0],
-                    mid=CONTINUOUS_GRADIENTS[gradient_index][1],
-                    high=CONTINUOUS_GRADIENTS[gradient_index][2]
+                    high=CONTINUOUS_GRADIENTS[gradient_index][1]
                 ))
                 gradient_index = (gradient_index + 1) % len(CONTINUOUS_GRADIENTS)
                 self.add_code('Image("{plot}")'.format(plot=filename),
@@ -395,8 +394,7 @@ class MMEDSNotebook():
                     subplot=subplot,
                     cat=column,
                     low=CONTINUOUS_GRADIENTS[gradient_index][0],
-                    mid=CONTINUOUS_GRADIENTS[gradient_index][1],
-                    high=CONTINUOUS_GRADIENTS[gradient_index][2]
+                    high=CONTINUOUS_GRADIENTS[gradient_index][1]
                 ))
                 gradient_index = (gradient_index + 1) % len(CONTINUOUS_GRADIENTS)
             else:

--- a/mmeds/summary.py
+++ b/mmeds/summary.py
@@ -339,7 +339,7 @@ class MMEDSNotebook():
         if True in [val for (key, val) in self.config['metadata_continuous'].items()]:
             self.add_code(self.source['alpha_py_continuous'].format(file1=data_file))
             gradient_index = 0
-            for col in [col for col in self.config['metadata'] if self.config['metadata_continuous'][col]]:
+            for col in sorted([col for col in self.config['metadata'] if self.config['metadata_continuous'][col]]):
                 filename = data_file.split('.')[0] + '_' + col + '.png'
                 self.add_code(self.source['alpha_r_continuous'].format(
                     file1=filename,

--- a/mmeds/summary.py
+++ b/mmeds/summary.py
@@ -7,7 +7,7 @@ from shutil import copy, rmtree, make_archive
 
 import nbformat as nbf
 import os
-from mmeds.config import STORAGE_DIR
+from mmeds.config import STORAGE_DIR, CONTINUOUS_GRADIENTS
 from mmeds.util import load_config, setup_environment, parse_code_blocks
 from mmeds.logging import Logger
 
@@ -338,9 +338,18 @@ class MMEDSNotebook():
         # Study contains continuous variables
         if True in [val for (key, val) in self.config['metadata_continuous'].items()]:
             self.add_code(self.source['alpha_py_continuous'].format(file1=data_file))
+            gradient_index = 0
             for col in [col for col in self.config['metadata'] if self.config['metadata_continuous'][col]]:
                 filename = data_file.split('.')[0] + '_' + col + '.png'
-                self.add_code(self.source['alpha_r_continuous'].format(file1=filename, xaxis=xaxis, cat=col))
+                self.add_code(self.source['alpha_r_continuous'].format(
+                    file1=filename,
+                    xaxis=xaxis,
+                    cat=col,
+                    low=CONTINUOUS_GRADIENTS[gradient_index][0],
+                    mid=CONTINUOUS_GRADIENTS[gradient_index][1],
+                    high=CONTINUOUS_GRADIENTS[gradient_index][2]
+                ))
+                gradient_index = (gradient_index + 1) % len(CONTINUOUS_GRADIENTS)
                 self.add_code('Image("{plot}")'.format(plot=filename),
                             meta={column: True for column in self.config['metadata'] if self.config['metadata_continuous'][column]})
                 self.add_markdown(self.source['page_break'])
@@ -369,8 +378,9 @@ class MMEDSNotebook():
         elif 'weighted' in data_file:
             display_name = 'Weighted UniFrac'
         else:
-            #TODO: Remove Jaccard so this isn't necessary
+            # TODO: Remove Jaccard so this isn't necessary
             return
+        gradient_index = 0
         for column in sorted(self.config['metadata']):
             plot = '{}-{}.png'.format(data_file.split('.')[0], column)
             subplot = '{}-%s-%s.png'.format(plot.split('.')[0])
@@ -383,8 +393,12 @@ class MMEDSNotebook():
                 self.add_code(self.source['beta_r_continuous'].format(
                     plot=plot,
                     subplot=subplot,
-                    cat=column
+                    cat=column,
+                    low=CONTINUOUS_GRADIENTS[gradient_index][0],
+                    mid=CONTINUOUS_GRADIENTS[gradient_index][1],
+                    high=CONTINUOUS_GRADIENTS[gradient_index][2]
                 ))
+                gradient_index = (gradient_index + 1) % len(CONTINUOUS_GRADIENTS)
             else:
                 self.add_code(self.source['beta_py_discrete'].format(
                     file1=data_file,


### PR DESCRIPTION
# Pull Request Template for MMEDS

## What has changed
Colors in summaries have been revamped for alpha and beta diversity. Three continuous gradients are now used to display continuous variables. Discrete variables take from the brewer color palette "Set1". This will look very good if the total number of discrete options across all discrete variables is <= 8. It will become somewhat less clear between variables when > 8 (i.e. worst case, a discrete set might be colored yellow, orange, and brown). Text in PCOA plots is less intrusive, allowing the focus of the plots to be on the colored points. 

This PR also includes the removal of many lines that related to the old way summaries generated continuous colors.

## Checklist of pre-requisites
-   [x] Does the code run?  
-   [x] Does the code follow the repository style?  
-   [x] Is the code tested?  

## How to use the feature
Run a summary as usual.

## Additional notes
Closes #362
Closes #360 
Closes #366 